### PR TITLE
fix: pin container image digest to prevent TOCTOU (verify→prepare→publish)

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -43,6 +43,7 @@ jobs:
           id: get-digest
           run: |
             DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://ghcr.io/xlionjuan/fedora-createrepo-image:latest)
+            echo "Resolved digest: ${DIGEST}"
             echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
         - name: Verify

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -39,19 +39,19 @@ jobs:
         - name: Install Cosign
           uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+        - name: Get image digest
+          id: get-digest
+          run: |
+            DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://ghcr.io/xlionjuan/fedora-createrepo-image:latest)
+            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
         - name: Verify
           run: |
             set -euo pipefail
             cosign verify --rekor-url=https://rekor.sigstore.dev \
             --certificate-identity-regexp "https://github.com/xlionjuan/.*" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            ghcr.io/xlionjuan/fedora-createrepo-image:latest
-
-        - name: Get image digest
-          id: get-digest
-          run: |
-            DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://ghcr.io/xlionjuan/fedora-createrepo-image:latest)
-            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+            ghcr.io/xlionjuan/fedora-createrepo-image@${{ steps.get-digest.outputs.digest }}
 
   prepare:
     name: Prepare

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -33,6 +33,8 @@ jobs:
   verify:
     name: Verify container
     runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.get-digest.outputs.digest }}
     steps:
         - name: Install Cosign
           uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -45,11 +47,17 @@ jobs:
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             ghcr.io/xlionjuan/fedora-createrepo-image:latest
 
+        - name: Get image digest
+          id: get-digest
+          run: |
+            DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://ghcr.io/xlionjuan/fedora-createrepo-image:latest)
+            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
   prepare:
     name: Prepare
     runs-on: ubuntu-24.04-arm
     needs: verify
-    container: ghcr.io/xlionjuan/fedora-createrepo-image:latest
+    container: ghcr.io/xlionjuan/fedora-createrepo-image@${{ needs.verify.outputs.digest }}
     steps:
         - name: Checkout code
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -160,9 +168,9 @@ jobs:
   publish:
     name: Publish and sign repository
     runs-on: ubuntu-24.04-arm
-    needs: prepare
+    needs: [prepare, verify]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    container: ghcr.io/xlionjuan/fedora-createrepo-image:latest
+    container: ghcr.io/xlionjuan/fedora-createrepo-image@${{ needs.verify.outputs.digest }}
     steps:
         - name: Download aptly workspace
           uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary

Closes TOCTOU window between `cosign verify` (which checks `:latest`) and the actual container runtime in `prepare`/`publish` jobs.

### Problem

```
T0: verify job checks fedora-createrepo-image:latest → clean ✓
T1: latest tag moves to a new image
T2: prepare/publish jobs pull :latest → different image, never verified
```

The `needs: verify` dependency guarantees ordering, but not that both jobs see the same image.

### Fix

1. **verify job** — after cosign verification, captures the actual digest via `skopeo inspect`, exposes as job output
2. **prepare job** — `container: image: ...@${{ needs.verify.outputs.digest }}`
3. **publish job** — `needs: [prepare, verify]`, `container: image: ...@${{ needs.verify.outputs.digest }}`

All three jobs now operate on the exact same SHA256 digest that passed cosign verification.

### Why skopeo

`skopeo` is already available on `ubuntu-24.04-arm` runners (pre-installed). No new dependencies. It directly queries the registry for the manifest digest without pulling the image.

### Why publish needs verify in addition to prepare

`needs` context only exposes **direct** dependencies. Since publish must consume `verify.outputs.digest`, verify must be a direct dependency. Adding verify alongside prepare does not change execution order — prepare already depends on verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to enhance container image handling. Container images are now pinned using immutable digests instead of latest tags. Image verification includes digest resolution and validation, ensuring all deployment jobs use consistent and properly verified container images throughout the pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xlionjuan/ntpd-rs-repos/pull/32)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->